### PR TITLE
Set a default for the DEVKITPRO environment variable.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,8 +181,10 @@ pub fn get_metadata(messages: &[Message]) -> NTRConfig {
 
     let mut icon = String::from("./icon.bmp");
 
+    let devkitpro = env::var("DEVKITPRO").unwrap_or_else(|_| String::from("/opt/devkitpro"));
+
     if !Path::new(&icon).exists() {
-        icon = format!("{}/libnds/icon.bmp", env::var("DEVKITPRO").unwrap());
+        icon = format!("{}/libnds/icon.bmp", devkitpro);
     }
     let description =
         (packages[0].description.clone()).unwrap_or_else(|| String::from("Homebrew app;;"));


### PR DESCRIPTION
This sets the a default value for the `DEVKITPRO` environment variable if it isn't already set; `/opt/devkitpro`. As far as I'm concerned this is very likely to be correct on any platform one uses Devkit on, even Windows (because you need MSYS2 to use it on that)